### PR TITLE
Order Monitor records by most recent first.

### DIFF
--- a/src/Controllers/ShowQueueMonitorController.php
+++ b/src/Controllers/ShowQueueMonitorController.php
@@ -24,6 +24,7 @@ class ShowQueueMonitorController extends Controller
             ->when($filters['onlyFailed'], static function (Builder $builder) {
                 $builder->where('failed', 1);
             })
+            ->ordered()
             ->paginate(
                 config('queue-monitor.ui.per_page')
             )


### PR DESCRIPTION
Order the list of Monitor records on the GUI page by most recent first.