### PR TITLE
Avoid duplicate job registration on distributed systems.

### DIFF
--- a/src/Services/QueueMonitor.php
+++ b/src/Services/QueueMonitor.php
@@ -115,7 +115,7 @@ class QueueMonitor
 
         $model = self::getModel();
 
-        $model::query()->create([
+        $monitor = $model::query()->create([
             'job_id' => self::getJobId($job),
             'name' => $job->resolveName(),
             'queue' => $job->getQueue(),
@@ -123,6 +123,11 @@ class QueueMonitor
             'started_at_exact' => $now->format(self::TIMESTAMP_EXACT_FORMAT),
             'attempt' => $job->attempts(),
         ]);
+
+        $model::query()
+            ->where('job_id', $monitor->job_id)
+            ->where('id', '!=', $monitor->id)
+            ->delete();
     }
 
     /**


### PR DESCRIPTION
https://github.com/romanzipp/Laravel-Queue-Monitor/issues/48

It seems that when jobs are distributed across multiple Laravel instances the Laravel queue monitor register the same job 2 or more times, but because only the last job is executed the older one keeps in the "running" state forever without any cause of error or timeout.

In order to avoid concurrency issues Laravel has implemented the "withoutOverlapping" and "onOneServer" methods, that will avoid to run a job more than one time per schedule and it works pretty well when the right cache is used (Like Redis), however the Laravel Queue Monitor can register more than one time the same job.

In the example attached to this pull request you can find a screenshot of the queue_monitor that show a job registered two times. If you observe the "started_at_exact" same job was registered with some milliseconds of difference.

![Screenshot 2021-05-20 at 14 28 07](https://user-images.githubusercontent.com/835173/118978629-d6261980-b977-11eb-8406-0888aaff9e96.png)

My pull request will delete the duplicate jobs avoiding to keep the jobs on running state. 