### PR TITLE
Make it so that connection is configurable for use cases with multiple DBs

### DIFF
--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -5,7 +5,7 @@ return [
      * Set the table to be used for monitoring data.
      */
     'table' => 'queue_monitor',
-    'connection' => config('database.default'),
+    'connection' => null,
 
     /*
      * Set the model used for monitoring.

--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -5,6 +5,7 @@ return [
      * Set the table to be used for monitoring data.
      */
     'table' => 'queue_monitor',
+    'connection' => config('database.default'),
 
     /*
      * Set the model used for monitoring.

--- a/src/Models/Monitor.php
+++ b/src/Models/Monitor.php
@@ -56,7 +56,10 @@ class Monitor extends Model implements MonitorContract
         parent::__construct($attributes);
 
         $this->setTable(config('queue-monitor.table'));
-        $this->setConnection(config('queue-monitor.connection'));
+
+        if ($connection = config('queue-monitor.connection')) {
+            $this->setConnection($connection);
+        }
     }
 
     /*

--- a/src/Models/Monitor.php
+++ b/src/Models/Monitor.php
@@ -56,6 +56,7 @@ class Monitor extends Model implements MonitorContract
         parent::__construct($attributes);
 
         $this->setTable(config('queue-monitor.table'));
+        $this->setConnection(config('queue-monitor.connection'));
     }
 
     /*


### PR DESCRIPTION
I set the connection in the Monitor model constructor just like the table. I used the 'default' connection for the base queue-monitor config since that is what it will be for most people, but it can be changed to whichever connection the developer desires.