### PR TITLE
Add configurable meta refresh

### DIFF
--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -55,6 +55,6 @@ return [
         /**
         * The interval before refreshing the dashboard (in seconds).
         */
-        'refresh-interval' => 10,
+        'refresh-interval' => null,
     ],
 ];

--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -51,5 +51,10 @@ return [
          * Time frame used to calculate metrics values (in days).
          */
         'metrics_time_frame' => 14,
+        
+        /**
+        * The interval before refreshing the dashboard (in seconds).
+        */
+        'refresh-interval' => 10,
     ],
 ];

--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -53,8 +53,8 @@ return [
         'metrics_time_frame' => 14,
         
         /**
-        * The interval before refreshing the dashboard (in seconds).
-        */
+         * The interval before refreshing the dashboard (in seconds).
+         */
         'refresh-interval' => null,
     ],
 ];

--- a/views/jobs.blade.php
+++ b/views/jobs.blade.php
@@ -5,6 +5,9 @@
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    @if(config('queue-monitor.ui.refresh-interval'))
+        <meta http-equiv="refresh" content="{{ config('queue-monitor.ui.refresh-interval') }}">
+    @endif
 
     <title>@lang('Queue Monitor')</title>
 


### PR DESCRIPTION
Although an ajax-based solution would be certainly better, this PR adds a refreshing interval to the dashboard view using a simple `<meta http-equiv="refresh">` tag with configurable interval.