### PR TITLE
l10 deprecated dates refactor

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,11 @@ jobs:
       matrix:
         php: [ "7.2", "7.3", "7.4", "8.0", "8.1", "8.2" ]
         composer-dependency: [ prefer-stable, prefer-lowest ]
+        exclude:
+          - php: "8.1"
+            composer-dependency: prefer-lowest
+          - php: "8.2"
+            composer-dependency: prefer-lowest
 
     name: "PHP ${{ matrix.php }} - ${{ matrix.composer-dependency }}"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
   test:
@@ -8,8 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]
-        composer-dependency: [prefer-stable, prefer-lowest]
+        php: [ "7.2", "7.3", "7.4", "8.0", "8.1", "8.2" ]
+        composer-dependency: [ prefer-stable, prefer-lowest ]
 
     name: "PHP ${{ matrix.php }} - ${{ matrix.composer-dependency }}"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0]
+        php: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]
         composer-dependency: [prefer-stable, prefer-lowest]
 
     name: "PHP ${{ matrix.php }} - ${{ matrix.composer-dependency }}"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Latest Stable Version](https://img.shields.io/packagist/v/romanzipp/laravel-queue-monitor.svg?style=flat-square)](https://packagist.org/packages/romanzipp/laravel-queue-monitor)
 [![Total Downloads](https://img.shields.io/packagist/dt/romanzipp/laravel-queue-monitor.svg?style=flat-square)](https://packagist.org/packages/romanzipp/laravel-queue-monitor)
 [![License](https://img.shields.io/packagist/l/romanzipp/laravel-queue-monitor.svg?style=flat-square)](https://packagist.org/packages/romanzipp/laravel-queue-monitor)
-[![GitHub Build Status](https://img.shields.io/github/workflow/status/romanzipp/Laravel-Queue-Monitor/Tests?style=flat-square)](https://github.com/romanzipp/Laravel-Queue-Monitor/actions)
+[![GitHub Build Status](https://img.shields.io/github/actions/workflow/status/romanzipp/Laravel-Queue-Monitor/tests.yml?branch=master&label=tests&style=flat-square)](https://github.com/romanzipp/Laravel-Queue-Monitor/actions)
 
 This package offers monitoring like [Laravel Horizon](https://laravel.com/docs/horizon) for database queue.
 

--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,16 @@
         "php": "^7.2|^8.0",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "illuminate/database": "^5.5|^6.0|^7.0|^8.0|^9.0",
-        "illuminate/queue": "^5.5|^6.0|^7.0|^8.0|^9.0",
-        "illuminate/support": "^5.5|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/database": "^5.5|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/queue": "^5.5|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/support": "^5.5|^6.0|^7.0|^8.0|^9.0|^10.0",
         "nesbot/carbon": "^2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
-        "laravel/framework": "^5.5|^6.0|^7.0|^8.0|^9.0",
+        "laravel/framework": "^5.5|^6.0|^7.0|^8.0|^9.0|^10.0",
         "mockery/mockery": "^1.3.2",
-        "orchestra/testbench": "^3.8|^4.0|^5.0|^6.0",
+        "orchestra/testbench": ">=3.8",
         "phpstan/phpstan": "^0.12.99|^1.0",
         "phpunit/phpunit": "^8.0|^9.0",
         "romanzipp/php-cs-fixer-config": "^3.0"

--- a/src/Models/Monitor.php
+++ b/src/Models/Monitor.php
@@ -44,14 +44,8 @@ class Monitor extends Model implements MonitorContract
      */
     protected $casts = [
         'failed' => 'bool',
-    ];
-
-    /**
-     * @var string[]
-     */
-    protected $dates = [
-        'started_at',
-        'finished_at',
+        'started_at' => 'datetime',
+        'finished_at' => 'datetime',
     ];
 
     /**


### PR DESCRIPTION
https://laravel.com/docs/10.x/upgrade#model-dates-property

Laravel 10 removed the `$dates` property that had deprecated in the previous version. Moving the dates to the `casts` property maintains the functionality and is backwards compatible.