### PR TITLE
Refactors the removed property dates to use the casts property.

### DIFF
--- a/src/Models/Monitor.php
+++ b/src/Models/Monitor.php
@@ -44,14 +44,8 @@ class Monitor extends Model implements MonitorContract
      */
     protected $casts = [
         'failed' => 'bool',
-    ];
-
-    /**
-     * @var string[]
-     */
-    protected $dates = [
-        'started_at',
-        'finished_at',
+        'started_at' => 'datetime',
+        'finished_at' => 'datetime',
     ];
 
     /**


### PR DESCRIPTION
https://laravel.com/docs/10.x/upgrade#model-dates-property

Laravel 10 removed the `$dates` property that had deprecated in the previous version. Moving the dates to the `casts` property maintains the functionality and is backwards compatible.