### PR TITLE
Update QueueMonitor::shouldBeMonitored

### DIFF
--- a/src/Services/QueueMonitor.php
+++ b/src/Services/QueueMonitor.php
@@ -211,7 +211,7 @@ class QueueMonitor
     public static function shouldBeMonitored(JobContract $job): bool
     {
         return array_key_exists(IsMonitored::class, ClassUses::classUsesRecursive(
-            $job->resolveName()
+            $job->payload()['data']['commandName']
         ));
     }
 }


### PR DESCRIPTION
`QueueMonitor::shouldBeMonitored` calls `Job::resolveName()` to retrieve the class of the job. But `resolveName()` can be overridden by the method `displayName()` if it is exist in the job class. The real classname is located in the payload of the job.