### PR TITLE
Remove Eloquent usage in UpdateQueueMonitorTable migration

### DIFF
--- a/migrations/2023_03_01_000000_update_queue_monitor_table.php
+++ b/migrations/2023_03_01_000000_update_queue_monitor_table.php
@@ -1,12 +1,11 @@
 <?php
 
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use romanzipp\QueueMonitor\Enums\MonitorStatus;
-use romanzipp\QueueMonitor\Models\Monitor;
 
 class UpdateQueueMonitorTable extends Migration
 {
@@ -25,8 +24,9 @@ class UpdateQueueMonitorTable extends Migration
 
     public function upgradeColumns()
     {
-        Monitor::query()->chunk(500, function (Collection $monitors) {
-            /** @var array<int, array<\romanzipp\QueueMonitor\Models\Monitor>> $matrix */
+        DB::table(config('queue-monitor.table'))->orderBy('id')->chunk(500, function (Collection $monitors) {
+
+            /** @var array<int, array<stdClass>> $matrix */
             $matrix = [
                 MonitorStatus::RUNNING => [],
                 MonitorStatus::FAILED => [],
@@ -46,7 +46,7 @@ class UpdateQueueMonitorTable extends Migration
 
             foreach ($matrix as $status => $monitors) {
                 DB::table(config('queue-monitor.table'))
-                    ->whereIn('id', array_map(fn (Monitor $monitor) => $monitor->id, $monitors))
+                    ->whereIn('id', array_map(fn (stdClass $monitor) => $monitor->id, $monitors))
                     ->update(['status' => $status]);
             }
         });


### PR DESCRIPTION
**This PR updates the `UpdateQueueMonitorTable` migration to use `DB::table` everywhere rather than Eloquent to select existing items in the `\UpdateQueueMonitorTable::upgradeColumns` method.**

It's usually preferable to avoid referencing Eloquent models during migrations - the definition, fields, methods etc. of the model may change over time such that it no longer aligns with the state of the database as of when the migration was introduced.

Additionally, since the `Monitor` model may in fact be configured to use a specific connection, using it breaks the migration when for whatever reason the migration needs to run using a different connection -- note that `DB::table()->update()` on line 48 will always use the current default connection (which is, in my opinion, the desired behaviour), so there was a fundamental inconsistency there regardless;

Updating the migration as proposed in the PR fixed a problem for me in a multitenant application that runs database migration tests in a separate (temporary) database upon every release. I have the `Monitor` model configured to use the central database in the context of an application that has a central database and several tenant-specific databases, where the queue_monitor table goes in the central database.