### PR TITLE
Prevent error in migration with SQLite driver

### DIFF
--- a/migrations/2023_05_03_144452_add_job_uuid_and_retried_to_queue_monitor_table.php
+++ b/migrations/2023_05_03_144452_add_job_uuid_and_retried_to_queue_monitor_table.php
@@ -27,8 +27,10 @@ class AddJobUuidAndRetriedToQueueMonitorTable extends Migration
     public function down()
     {
         Schema::table(config('queue-monitor.table'), function (Blueprint $table) {
-            $table->dropColumn('job_uuid');
-            $table->dropColumn('retried');
+            $table->dropColumn([
+                'job_uuid',
+                'retried',
+            ]);
         });
     }
 }


### PR DESCRIPTION
Prevent error: "SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification."