### PR TITLE
fix: cast jobId to string because job_id column indexed in database is varchar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
-    "name": "romanzipp/laravel-queue-monitor",
+    "name": "uocnv/laravel-queue-monitor",
     "description": "Queue Monitoring for Laravel Database Job Queue",
     "type": "library",
     "license": "MIT",
     "authors": [
         {
-            "name": "romanzipp",
-            "email": "ich@ich.wtf",
-            "homepage": "https://ich.wtf"
+            "name": "Nguyễn Văn Ước",
+            "email": "uocnv.soict.hust@gmail.com",
+            "role": "Developer"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
-    "name": "uocnv/laravel-queue-monitor",
+    "name": "romanzipp/laravel-queue-monitor",
     "description": "Queue Monitoring for Laravel Database Job Queue",
     "type": "library",
     "license": "MIT",
     "authors": [
         {
-            "name": "Nguyễn Văn Ước",
-            "email": "uocnv.soict.hust@gmail.com",
-            "role": "Developer"
+            "name": "romanzipp",
+            "email": "ich@ich.wtf",
+            "homepage": "https://ich.wtf"
         }
     ],
     "require": {

--- a/src/Services/QueueMonitor.php
+++ b/src/Services/QueueMonitor.php
@@ -94,12 +94,12 @@ class QueueMonitor
      *
      * @param JobContract $job
      *
-     * @return string|int
+     * @return string
      */
-    public static function getJobId(JobContract $job): string|int
+    public static function getJobId(JobContract $job): string
     {
         if ($jobId = $job->getJobId()) {
-            return $jobId;
+            return (string)$jobId;
         }
 
         return sha1($job->getRawBody());


### PR DESCRIPTION
Because job_id column indexed in database is varchar, if not cast $jobId to string, query is slow, not use index in query

Example with 2M rows in database:
Before
![image](https://github.com/romanzipp/Laravel-Queue-Monitor/assets/43318488/57bc638e-c0e1-4583-9b18-006dc84562f6)

After
![image](https://github.com/romanzipp/Laravel-Queue-Monitor/assets/43318488/e64b5fae-27fb-4b20-9424-92375f1b8025)
