### PR TITLE
Add config option to order queued but not started jobs first

### DIFF
--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -53,5 +53,8 @@ return [
 
         // The interval before refreshing the dashboard (in seconds).
         'refresh_interval' => null,
+
+        // Order the queued but not started jobs first
+        'order_queued_first' => false
     ],
 ];

--- a/src/Controllers/ShowQueueMonitorController.php
+++ b/src/Controllers/ShowQueueMonitorController.php
@@ -54,9 +54,8 @@ class ShowQueueMonitorController
             $jobsQuery->where('data', 'like', "%{$filters['custom_data']}%");
         }
 
+        $connection = DB::connection();
         if (config('queue-monitor.ui.order_queued_first')) {
-            $connection = DB::connection();
-
             if ($connection instanceof DatabaseConnections\MySqlConnection) {
                 $jobsQuery->orderByRaw('-`started_at`');
             }
@@ -68,6 +67,8 @@ class ShowQueueMonitorController
             if ($connection instanceof DatabaseConnections\SQLiteConnection) {
                 $jobsQuery->orderByRaw('started_at DESC NULLS FIRST');
             }
+        } elseif ($connection instanceof DatabaseConnections\PostgresConnection) {
+            $jobsQuery->orderByRaw('started_at DESC NULLS LAST');
         }
 
         $jobsQuery

--- a/src/Controllers/ShowQueueMonitorController.php
+++ b/src/Controllers/ShowQueueMonitorController.php
@@ -54,6 +54,22 @@ class ShowQueueMonitorController
             $jobsQuery->where('data', 'like', "%{$filters['custom_data']}%");
         }
 
+        if (config('queue-monitor.ui.order_queued_first')) {
+            $connection = DB::connection();
+
+            if ($connection instanceof DatabaseConnections\MySqlConnection) {
+                $jobsQuery->orderByRaw('-`started_at`');
+            }
+
+            if ($connection instanceof DatabaseConnections\SqlServerConnection) {
+                $jobsQuery->orderByRaw('(CASE WHEN [started_at] IS NULL THEN 0 ELSE 1 END)');
+            }
+
+            if ($connection instanceof DatabaseConnections\SQLiteConnection) {
+                $jobsQuery->orderByRaw('started_at DESC NULLS FIRST');
+            }
+        }
+
         $jobsQuery
             ->orderBy('started_at', 'desc')
             ->orderBy('started_at_exact', 'desc');


### PR DESCRIPTION
Hi!

This pull request is a proposition to add an option to sort the "Queued" job first. The default value is `false`, keeping the current ordering unchanged.

By default, the ordering on `started_at DESC` make the newly queued jobs (`MonitorStatus::QUEUED`) appear in last position.
This is because most DB engine (except PostgreSQL / Oracle) treat `NULL` as smaller value than any other values (see the reference table)

For me, it feels "wrong" as these items are technically the newest on the queue. Also, I find seeing on the first page the number of queued jobs is a good monitoring information to know if the worker is overwhelmed.

This PR also aligns PostgreSQL to the sorting of `NULL` values of other engines. This is _technically_ a breaking change, as PostgresSQL currently put `NULL` first but I think having the display order being the same across all engines qualify more as a fix than a change.

## Reference

<table cellspacing="0" summary="">
<thead>
  <tr class="bg-light-blue">
    <th></th><th>ASC</th><th>DESC</th>
  </tr>
</thead>
<tfoot>
</tfoot>
<tbody>
  <tr>
    <td class="bg-light-blue">NULLs appear first</td><td>SQL Server, MySQL, SQLite</td><td>PostgreSQL, Oracle</td>
  </tr>
  <tr>
    <td class="bg-light-blue">NULLs appear last</td><td>PostgreSQL, Oracle</td><td>SQL Server, MySQL, SQLite</td>
  </tr>
</tbody>
</table>
