### PR TITLE
Actually delete all monitors when purging

### DIFF
--- a/src/Controllers/PurgeMonitorsController.php
+++ b/src/Controllers/PurgeMonitorsController.php
@@ -13,9 +13,7 @@ class PurgeMonitorsController
     {
         $model = QueueMonitor::getModel();
 
-        $model->newQuery()->each(function (MonitorContract $monitor) {
-            $monitor->delete();
-        }, 200);
+        $model->newQuery()->delete();
 
         return redirect()->route('queue-monitor::index');
     }


### PR DESCRIPTION
Using this at my job, I found it kind of weird that the "Delete all entries" button didn't delete all monitor entries, and only the first 200.
This PR fixes that, and the button will now delete all QueueMonitor models.