### PR TITLE
rename colum from 'failed' to 'status' in scopeFailed

### DIFF
--- a/src/Models/Monitor.php
+++ b/src/Models/Monitor.php
@@ -110,7 +110,7 @@ class Monitor extends Model implements MonitorContract
 
     public function scopeFailed(Builder $query): void
     {
-        $query->where('failed', MonitorStatus::FAILED);
+        $query->where('status', MonitorStatus::FAILED);
     }
 
     public function scopeSucceeded(Builder $query): void


### PR DESCRIPTION
scopeFailed function used failed column instead of status