### PR TITLE
Prevent json_encode on null value from initialMonitorData() on job queue

### DIFF
--- a/src/Services/QueueMonitor.php
+++ b/src/Services/QueueMonitor.php
@@ -132,7 +132,10 @@ class QueueMonitor
 
         // add initial data
         if (method_exists($event->job, 'initialMonitorData')) {
-            $data = json_encode($event->job->initialMonitorData());
+            $initialData = $event->job->initialMonitorData();
+            if ($initialData !== null) {
+                $data = json_encode($initialData);
+            }
         }
 
         QueueMonitor::getModel()::query()->create([


### PR DESCRIPTION
Currently, the return value of `initialMonitorData()` is always json encoded. Even if the return value is `null`. This PR should prevent that from happening. Similar logic is already in place for `jobPushed`