### PR TITLE
Fix: return correct exit code on successful command execution

### DIFF
--- a/src/Console/Commands/PurgeOldMonitorsCommand.php
+++ b/src/Console/Commands/PurgeOldMonitorsCommand.php
@@ -72,6 +72,6 @@ class PurgeOldMonitorsCommand extends Command
             );
         }
 
-        return 1;
+        return 0;
     }
 }


### PR DESCRIPTION
Hi! 👋
I noticed that this command was returning an exit code of 1 even when it completed successfully. This caused some unexpected behavior with monitoring tools such as Sentry cron monitoring which rely on the commands exit code to decide whether to trigger their `onSuccess` or `onFailure` handlers. Because of the non-zero exit code, these systems interpreted successful runs as failures and sent incorrect failure check-ins.

This PR updates the command to return 0 on success, following the standard exit-code conventions. It’s a small change, but I thought it would be a nice improvement to help avoid misleading error reports in setups that monitor exit codes.

Thanks for maintaining this package! 🚀 