### PR TITLE
Fixed a problem when filtering "All" status

### DIFF
--- a/src/Controllers/ShowQueueMonitorController.php
+++ b/src/Controllers/ShowQueueMonitorController.php
@@ -30,7 +30,7 @@ class ShowQueueMonitorController
         ]);
 
         $filters = [
-            'status' => isset($data['status']) ? (int) $data['status'] : null,
+            'status' => filled($data['status'] ?? null) ? (int) $data['status'] : null,
             'queue' => $data['queue'] ?? 'all',
             'name' => $data['name'] ?? null,
             'custom_data' => $data['custom_data'] ?? null,

--- a/tests/RoutesTest.php
+++ b/tests/RoutesTest.php
@@ -40,6 +40,34 @@ class RoutesTest extends DatabaseTestCase
             ->assertViewIs('queue-monitor::jobs');
     }
 
+    public function testIndexStatusFilterAll()
+    {
+        config(['queue-monitor.ui.enabled' => true]);
+
+        Monitor::query()->create(['job_id' => mt_rand(), 'status' => MonitorStatus::RUNNING]);
+        Monitor::query()->create(['job_id' => mt_rand(), 'status' => MonitorStatus::FAILED]);
+
+        $this
+            ->get('/jobs?status=')
+            ->assertStatus(200)
+            ->assertViewHas('filters', fn (array $filters) => null === $filters['status'])
+            ->assertViewHas('jobs', fn ($jobs) => 2 === $jobs->total());
+    }
+
+    public function testIndexStatusFilterRunning()
+    {
+        config(['queue-monitor.ui.enabled' => true]);
+
+        Monitor::query()->create(['job_id' => mt_rand(), 'status' => MonitorStatus::RUNNING]);
+        Monitor::query()->create(['job_id' => mt_rand(), 'status' => MonitorStatus::FAILED]);
+
+        $this
+            ->get('/jobs?status=0')
+            ->assertStatus(200)
+            ->assertViewHas('filters', fn (array $filters) => MonitorStatus::RUNNING === $filters['status'])
+            ->assertViewHas('jobs', fn ($jobs) => 1 === $jobs->total());
+    }
+
     /*
      *--------------------------------------------------------------------------
      * Delete Monitor


### PR DESCRIPTION
When you select "All" status and hit "Apply Filter", the "All" doesn't stay as "All". It goes down to "Running".