### PR TITLE
Fixed incorrect "Started" intervals if the Laravel timezone and database timezone are different

### DIFF
--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -6,6 +6,19 @@ return [
     'connection' => null,
 
     /*
+     * Timezone used to interpret the started_at_exact / finished_at_exact string
+     * columns when displaying timestamps. Falls back to app.timezone.
+     */
+    'monitor_timezone' => env('QUEUE_MONITOR_TIMEZONE'),
+
+    /*
+     * Timezone used to interpret the started_at / finished_at database columns
+     * when they differ from Laravel's app timezone. Falls back to the database
+     * connection timezone, then app.timezone.
+     */
+    'database_timezone' => env('QUEUE_MONITOR_DB_TIMEZONE'),
+
+    /*
      * Set the model used for monitoring.
      * If using a custom model, be sure to implement the
      *   romanzipp\QueueMonitor\Models\Contracts\MonitorContract

--- a/src/Models/Monitor.php
+++ b/src/Models/Monitor.php
@@ -134,6 +134,57 @@ class Monitor extends Model implements MonitorContract
         return Carbon::parse($this->started_at_exact);
     }
 
+    /**
+     * Get the job start time for display, correcting for database timezone skew.
+     */
+    public function getDisplayStartedAt(): ?Carbon
+    {
+        if (null !== $this->started_at_exact) {
+            return Carbon::parse($this->started_at_exact, $this->resolveMonitorTimezone());
+        }
+
+        $raw = $this->getRawOriginal('started_at');
+
+        if (null === $raw) {
+            return null;
+        }
+
+        return Carbon::parse($raw, $this->resolveDatabaseTimezone());
+    }
+
+    /**
+     * Format the display start time with its timezone identifier.
+     */
+    public function formatDisplayStartedAt(): ?string
+    {
+        if (null === ($startedAt = $this->getDisplayStartedAt())) {
+            return null;
+        }
+
+        return sprintf(
+            '%s %s',
+            $startedAt->format('Y-m-d H:i:s'),
+            $startedAt->getTimezone()->getName()
+        );
+    }
+
+    protected function resolveMonitorTimezone(): string
+    {
+        return config('queue-monitor.monitor_timezone') ?? config('app.timezone');
+    }
+
+    protected function resolveDatabaseTimezone(): string
+    {
+        if ($timezone = config('queue-monitor.database_timezone')) {
+            return $timezone;
+        }
+
+        $connection = $this->getConnectionName();
+
+        return config("database.connections.{$connection}.timezone")
+            ?? config('app.timezone');
+    }
+
     public function getFinishedAtExact(): ?Carbon
     {
         if (null === $this->finished_at_exact) {

--- a/tests/MonitorDisplayStartedAtTest.php
+++ b/tests/MonitorDisplayStartedAtTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace romanzipp\QueueMonitor\Tests;
+
+use Illuminate\Support\Carbon;
+use romanzipp\QueueMonitor\Models\Monitor;
+use romanzipp\QueueMonitor\Tests\TestCases\DatabaseTestCase;
+
+class MonitorDisplayStartedAtTest extends DatabaseTestCase
+{
+    public function testDisplayStartedAtReturnsNullWhenNotStarted(): void
+    {
+        $monitor = new Monitor();
+
+        self::assertNull($monitor->getDisplayStartedAt());
+    }
+
+    public function testDisplayStartedAtPrefersStartedAtExact(): void
+    {
+        config(['queue-monitor.monitor_timezone' => 'America/New_York']);
+
+        $monitor = new Monitor();
+        $monitor->setRawAttributes([
+            'started_at' => '2020-01-01 15:00:00',
+            'started_at_exact' => '2020-01-01 10:00:00.000000',
+        ]);
+
+        $expected = Carbon::parse('2020-01-01 10:00:00.000000', 'America/New_York');
+
+        self::assertTrue($expected->equalTo($monitor->getDisplayStartedAt()));
+    }
+
+    public function testDisplayStartedAtUsesDatabaseTimezoneForStartedAtColumn(): void
+    {
+        config([
+            'app.timezone' => 'UTC',
+            'queue-monitor.database_timezone' => 'America/New_York',
+        ]);
+
+        $monitor = new Monitor();
+        $monitor->setRawAttributes([
+            'started_at' => '2020-01-01 10:00:00',
+            'started_at_exact' => null,
+        ]);
+
+        $expected = Carbon::parse('2020-01-01 10:00:00', 'America/New_York');
+
+        self::assertTrue($expected->equalTo($monitor->getDisplayStartedAt()));
+    }
+
+    public function testDisplayStartedAtDiffForHumansUsesPastTime(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2020-01-01 12:00:00', 'UTC'));
+
+        config([
+            'app.timezone' => 'UTC',
+            'queue-monitor.database_timezone' => 'UTC',
+        ]);
+
+        $monitor = new Monitor();
+        $monitor->setRawAttributes([
+            'started_at' => '2020-01-01 10:00:00',
+            'started_at_exact' => null,
+        ]);
+
+        self::assertStringContainsString('ago', $monitor->getDisplayStartedAt()->diffForHumans());
+
+        Carbon::setTestNow();
+    }
+
+    public function testFormatDisplayStartedAtIncludesTimezone(): void
+    {
+        config(['queue-monitor.monitor_timezone' => 'America/New_York']);
+
+        $monitor = new Monitor();
+        $monitor->setRawAttributes([
+            'started_at_exact' => '2020-01-01 10:00:00.000000',
+        ]);
+
+        self::assertSame(
+            '2020-01-01 10:00:00 America/New_York',
+            $monitor->formatDisplayStartedAt()
+        );
+    }
+}

--- a/views/partials/table.blade.php
+++ b/views/partials/table.blade.php
@@ -99,8 +99,11 @@
                     {{ $job->getElapsedInterval()->format('%H:%I:%S') }}
                 </td>
 
+                @php($displayStartedAt = $job->getDisplayStartedAt())
                 <td class="p-4 text-gray-800 dark:text-gray-300 text-sm leading-5 border-b border-gray-200 dark:border-gray-600">
-                    {{ $job->started_at?->diffForHumans() }}
+                    @if($displayStartedAt)
+                        <span title="{{ $job->formatDisplayStartedAt() }}">{{ $displayStartedAt->diffForHumans() }}</span>
+                    @endif
                 </td>
 
                 <td class="p-4 text-gray-800 dark:text-gray-300 text-sm leading-5 border-b border-gray-200 dark:border-gray-600">


### PR DESCRIPTION
If the Laravel timezone and database timezone are different, the "Started" column could contain values like "in 4 hours".

While I was there, I added a mouse-over text of the actual date and time it started.