### PR TITLE
Added Queued column, to show when the job first got queued

### DIFF
--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -37,6 +37,9 @@ return [
         // Show custom data stored on model
         'show_custom_data' => false,
 
+        // Show the time when the job was first enqueued.
+        'show_queued_at' => false,
+
         // Allow the deletion of single monitor items.
         'allow_deletion' => true,
 

--- a/src/Models/Monitor.php
+++ b/src/Models/Monitor.php
@@ -134,6 +134,127 @@ class Monitor extends Model implements MonitorContract
         return Carbon::parse($this->started_at_exact);
     }
 
+    /**
+     * Get the job start time for display, correcting for database timezone skew.
+     */
+    public function getDisplayStartedAt(): ?Carbon
+    {
+        if (null !== $this->started_at_exact) {
+            return Carbon::parse($this->started_at_exact, $this->resolveMonitorTimezone());
+        }
+
+        $raw = $this->getRawOriginal('started_at');
+
+        if (null === $raw) {
+            return null;
+        }
+
+        return Carbon::parse($raw, $this->resolveDatabaseTimezone());
+    }
+
+    /**
+     * Format the display start time with its timezone identifier.
+     */
+    public function formatDisplayStartedAt(): ?string
+    {
+        if (null === ($startedAt = $this->getDisplayStartedAt())) {
+            return null;
+        }
+
+        return sprintf(
+            '%s %s',
+            $startedAt->format('Y-m-d H:i:s'),
+            $startedAt->getTimezone()->getName()
+        );
+    }
+
+    /**
+     * Get the job enqueue time for display, correcting for database timezone skew.
+     */
+    public function getDisplayQueuedAt(): ?Carbon
+    {
+        $raw = $this->getRawOriginal('queued_at');
+
+        if (null === $raw) {
+            return null;
+        }
+
+        $queuedAt = Carbon::parse($raw, $this->resolveMonitorTimezone());
+
+        if (null === $this->started_at_exact) {
+            return $queuedAt;
+        }
+
+        $startedAt = Carbon::parse($this->started_at_exact, $this->resolveMonitorTimezone());
+
+        if ($queuedAt->gte($startedAt->copy()->subHour())) {
+            return $queuedAt;
+        }
+
+        $best = $queuedAt;
+
+        for ($hours = -12; $hours <= 12; $hours++) {
+            $candidate = $queuedAt->copy()->addHours($hours);
+
+            if ($candidate->lte($startedAt) && $candidate->gt($best)) {
+                $best = $candidate;
+            }
+        }
+
+        return $best;
+    }
+
+    /**
+     * Format the display enqueue time with its timezone identifier.
+     */
+    public function formatDisplayQueuedAt(): ?string
+    {
+        if (null === ($queuedAt = $this->getDisplayQueuedAt())) {
+            return null;
+        }
+
+        return sprintf(
+            '%s %s',
+            $queuedAt->format('Y-m-d H:i:s'),
+            $queuedAt->getTimezone()->getName()
+        );
+    }
+
+    protected function resolveMonitorTimezone(): string
+    {
+        return config('queue-monitor.monitor_timezone') ?? config('app.timezone');
+    }
+
+    protected function resolveDatabaseTimezone(): string
+    {
+        if ($timezone = config('queue-monitor.database_timezone')) {
+            return $timezone;
+        }
+
+        $connection = $this->getConnectionName();
+
+        return config("database.connections.{$connection}.timezone")
+            ?? config('app.timezone');
+    }
+
+    /**
+     * Get the job finish time for display, correcting for database timezone skew.
+     */
+    public function getDisplayFinishedAt(): ?Carbon
+    {
+        if (null !== $this->finished_at_exact) {
+            return Carbon::parse($this->finished_at_exact, $this->resolveMonitorTimezone());
+        }
+
+        $raw = $this->getRawOriginal('finished_at');
+
+        if (null === $raw) {
+            return null;
+        }
+
+        return Carbon::parse($raw, $this->resolveDatabaseTimezone());
+    }
+
     public function getFinishedAtExact(): ?Carbon
     {
         if (null === $this->finished_at_exact) {
@@ -188,14 +309,14 @@ class Monitor extends Model implements MonitorContract
 
     public function getElapsedInterval(?Carbon $end = null): CarbonInterval
     {
-        if (null === $end) {
-            $end = $this->getFinishedAtExact() ?? $this->finished_at ?? Carbon::now();
-        }
-
-        $startedAt = $this->getStartedAtExact() ?? $this->started_at;
+        $startedAt = $this->getDisplayStartedAt();
 
         if (null === $startedAt) {
             return CarbonInterval::seconds(0);
+        }
+
+        if (null === $end) {
+            $end = $this->getDisplayFinishedAt() ?? Carbon::now();
         }
 
         return $startedAt->diffAsCarbonInterval($end);

--- a/tests/MonitorTimeCalculationTest.php
+++ b/tests/MonitorTimeCalculationTest.php
@@ -76,6 +76,107 @@ class MonitorTimeCalculationTest extends DatabaseTestCase
         );
     }
 
+    public function testDisplayQueuedAtUsesMonitorTimezone()
+    {
+        config([
+            'app.timezone' => 'America/New_York',
+            'queue-monitor.monitor_timezone' => 'America/New_York',
+            'queue-monitor.database_timezone' => 'UTC',
+        ]);
+
+        Carbon::setTestNow(Carbon::parse('2025-06-22 12:00:00', 'America/New_York'));
+
+        /** @var Monitor $monitor */
+        $monitor = Monitor::query()->create([
+            'job_id' => sha1(Str::random()),
+            'queued_at' => now(),
+        ]);
+
+        $monitor->refresh();
+
+        self::assertLessThan(
+            60,
+            $monitor->getDisplayQueuedAt()->diffInSeconds(Carbon::now())
+        );
+
+        Carbon::setTestNow();
+    }
+
+    public function testElapsedIntervalUsesMonitorTimezoneForRunningJobs()
+    {
+        config([
+            'app.timezone' => 'UTC',
+            'queue-monitor.monitor_timezone' => 'America/New_York',
+        ]);
+
+        Carbon::setTestNow(Carbon::parse('2020-01-01 15:00:05', 'UTC'));
+
+        $monitor = new Monitor();
+        $monitor->setRawAttributes([
+            'started_at_exact' => '2020-01-01 10:00:00.000000',
+        ]);
+
+        self::assertEquals(
+            '00:00:05',
+            $monitor->getElapsedInterval()->format('%H:%I:%S')
+        );
+
+        Carbon::setTestNow();
+    }
+
+    public function testElapsedIntervalUsesMonitorTimezoneForFinishedJobs()
+    {
+        config([
+            'app.timezone' => 'UTC',
+            'queue-monitor.monitor_timezone' => 'America/New_York',
+            'queue-monitor.database_timezone' => 'UTC',
+        ]);
+
+        $monitor = new Monitor();
+        $monitor->setRawAttributes([
+            'started_at_exact' => '2020-01-01 10:00:00.000000',
+            'finished_at' => '2020-01-01 15:00:05',
+            'finished_at_exact' => null,
+        ]);
+
+        self::assertEquals(
+            '00:00:05',
+            $monitor->getElapsedInterval()->format('%H:%I:%S')
+        );
+    }
+
+    public function testDisplayQueuedAtCorrectsLegacyTimezoneSkew()
+    {
+        config([
+            'app.timezone' => 'UTC',
+            'queue-monitor.monitor_timezone' => 'UTC',
+        ]);
+
+        Carbon::setTestNow(Carbon::parse('2026-06-22 17:56:00', 'UTC'));
+
+        /** @var Monitor $monitor */
+        $monitor = Monitor::query()->create([
+            'job_id' => sha1(Str::random()),
+            'queued_at' => '2026-06-22 12:45:16',
+            'started_at' => Carbon::parse('2026-06-22 17:45:16', 'UTC'),
+            'started_at_exact' => '2026-06-22 17:45:16.000000',
+        ]);
+
+        $monitor->refresh();
+
+        self::assertLessThan(
+            900,
+            $monitor->getDisplayQueuedAt()->diffInSeconds(Carbon::now())
+        );
+
+        self::assertGreaterThan(
+            300,
+            $monitor->getDisplayQueuedAt()->diffInSeconds(Carbon::now())
+        );
+
+        Carbon::setTestNow();
+    }
+
     private function createMonitor(Carbon $startedAt, ?int $progress = null): Monitor
     {
         /** @var Monitor $monitor */

--- a/tests/RoutesTest.php
+++ b/tests/RoutesTest.php
@@ -40,6 +40,46 @@ class RoutesTest extends DatabaseTestCase
             ->assertViewIs('queue-monitor::jobs');
     }
 
+    public function testIndexShowsQueuedAtColumn()
+    {
+        config([
+            'queue-monitor.ui.enabled' => true,
+            'queue-monitor.ui.show_queued_at' => true,
+        ]);
+
+        Monitor::query()->create([
+            'job_id' => 'test',
+            'status' => MonitorStatus::SUCCEEDED,
+            'queued_at' => now()->subHours(2),
+            'started_at' => now()->subHour(),
+        ]);
+
+        $this
+            ->get('/jobs')
+            ->assertStatus(200)
+            ->assertSee('2 hours ago', false);
+    }
+
+    public function testIndexHidesQueuedAtColumnWhenDisabled()
+    {
+        config([
+            'queue-monitor.ui.enabled' => true,
+            'queue-monitor.ui.show_queued_at' => false,
+        ]);
+
+        Monitor::query()->create([
+            'job_id' => 'test',
+            'status' => MonitorStatus::SUCCEEDED,
+            'queued_at' => now()->subHours(2),
+            'started_at' => now()->subHour(),
+        ]);
+
+        $this
+            ->get('/jobs')
+            ->assertStatus(200)
+            ->assertDontSee('2 hours ago', false);
+    }
+
     /*
      *--------------------------------------------------------------------------
      * Delete Monitor

--- a/views/partials/table.blade.php
+++ b/views/partials/table.blade.php
@@ -13,6 +13,11 @@
 
             <th class="px-4 py-3 font-medium text-left text-xs text-gray-600 dark:text-gray-400 uppercase border-b border-gray-200 dark:border-gray-600">@lang('Progress')</th>
             <th class="px-4 py-3 font-medium text-left text-xs text-gray-600 dark:text-gray-400 uppercase border-b border-gray-200 dark:border-gray-600">@lang('Duration')</th>
+
+            @if(config('queue-monitor.ui.show_queued_at'))
+                <th class="px-4 py-3 font-medium text-left text-xs text-gray-600 dark:text-gray-400 uppercase border-b border-gray-200 dark:border-gray-600">@lang('Queued')</th>
+            @endif
+
             <th class="px-4 py-3 font-medium text-left text-xs text-gray-600 dark:text-gray-400 uppercase border-b border-gray-200 dark:border-gray-600">@lang('Started')</th>
             <th class="px-4 py-3 font-medium text-left text-xs text-gray-600 dark:text-gray-400 uppercase border-b border-gray-200 dark:border-gray-600">@lang('Error')</th>
 
@@ -99,8 +104,20 @@
                     {{ $job->getElapsedInterval()->format('%H:%I:%S') }}
                 </td>
 
+                @if(config('queue-monitor.ui.show_queued_at'))
+                    @php($displayQueuedAt = $job->getDisplayQueuedAt())
+                    <td class="p-4 text-gray-800 dark:text-gray-300 text-sm leading-5 border-b border-gray-200 dark:border-gray-600">
+                        @if($displayQueuedAt)
+                            <span title="{{ $job->formatDisplayQueuedAt() }}">{{ $displayQueuedAt->diffForHumans() }}</span>
+                        @endif
+                    </td>
+                @endif
+
+                @php($displayStartedAt = $job->getDisplayStartedAt())
                 <td class="p-4 text-gray-800 dark:text-gray-300 text-sm leading-5 border-b border-gray-200 dark:border-gray-600">
-                    {{ $job->started_at?->diffForHumans() }}
+                    @if($displayStartedAt)
+                        <span title="{{ $job->formatDisplayStartedAt() }}">{{ $displayStartedAt->diffForHumans() }}</span>
+                    @endif
                 </td>
 
                 <td class="p-4 text-gray-800 dark:text-gray-300 text-sm leading-5 border-b border-gray-200 dark:border-gray-600">


### PR DESCRIPTION
Added Queued column, to show when the job first got queued. This value is already stored, but never shown, so no migration is necessary.

This relies on a config setting "queue-monitor.ui.show_queued_at" which defaults to false, so the user won't see any change until he turns it on.